### PR TITLE
Update ORCID links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,15 +3,15 @@ Title: Estimate Vaccine Effectiveness Based on Different Study Designs
 Version: 0.0.1
 Authors@R: c(
     person(given = "Zulma M.", family = "Cucunubá", email = "zulma.cucunuba@javeriana.edu.co", role = c("aut", "cre"),
-        comment = c(ORCID = "https://orcid.org/0000-0002-8165-3198")),
+        comment = c(ORCID = "0000-0002-8165-3198")),
     person(given = "David Santiago", family = "Quevedo", email = "ex-dsquevedo@javeriana.edu.co", role = c("aut"),
-        comment = c(ORCID = "https://orcid.org/0000-0003-1583-4262")),
+        comment = c(ORCID = "0000-0003-1583-4262")),
     person(given = "Santiago", family = "Loaiza", email = "santiago.loaiza@javeriana.edu.co", role = c("aut"),
-        comment = c(ORCID = "https://orcid.org/0000-0002-2092-3262")),
+        comment = c(ORCID = "0000-0002-2092-3262")),
     person(given = "Geraldine", family = "Gómez Millán", email = "geralidine.gomez@javeriana.edu.co", role = c("ctb"),
-        comment = c(ORCID = "https://orcid.org/0009-0007-8701-0568")),
+        comment = c(ORCID = "0009-0007-8701-0568")),
     person(given = "Pratik", family = "Gupte", email = "pratik.gupte@lshtm.ac.uk", role = c("ctb"), 
-           comment = c(ORCID = "https://orcid.org/0000-0001-5294-7819"))
+           comment = c(ORCID = "0000-0001-5294-7819"))
   )
 Description: Estimate vaccine effectiveness based on different observational study designs, as discussed in Torvaldsen and McIntyre (2020) <doi:10.3316/informit.511798489353134>.
 URL: https://github.com/epiverse-trace/vaccineff, https://epiverse-trace.github.io/vaccineff/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(
     person(given = "Zulma M.", family = "Cucunubá", email = "zulma.cucunuba@javeriana.edu.co", role = c("aut", "cre"),
         comment = c(ORCID = "https://orcid.org/0000-0002-8165-3198")),
     person(given = "David Santiago", family = "Quevedo", email = "ex-dsquevedo@javeriana.edu.co", role = c("aut"),
-        comment = c(ORCID = "https://orcid.org/0000-0003-1583-4262)")),
+        comment = c(ORCID = "https://orcid.org/0000-0003-1583-4262")),
     person(given = "Santiago", family = "Loaiza", email = "santiago.loaiza@javeriana.edu.co", role = c("aut"),
         comment = c(ORCID = "https://orcid.org/0000-0002-2092-3262")),
     person(given = "Geraldine", family = "Gómez Millán", email = "geralidine.gomez@javeriana.edu.co", role = c("ctb"),


### PR DESCRIPTION
Removing an extra parenthesis in one of the contributor ORCIDs and removing the domain, as this causes #39.

Fixes #39 when merged.