### PR TITLE
Fix 38 age interval get age group

### DIFF
--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -69,7 +69,7 @@ get_age_group <- function(data, col_age, max_val, min_val = 0, step) {
 
   #Warning of module condition not satisfied
   if ((max_val - min_val) %% step != 0) {
-    war_msg <- "The values provided do not satisfy (max_val-min_val)%%step = 0.
+    war_msg <- "(max_val - min_val) must be an integer multiple of step.
     The last interval will be truncated to "
     war_msg <- paste0(war_msg, lim_labels[length(lim_labels)])
     warning(war_msg)

--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -31,7 +31,7 @@
 #'   data = cohortdata,
 #'   col_age = "age",
 #'   max_val = 80,
-#'   step = 9
+#'   step = 10
 #' )
 #'
 #' # view the data frame with new column

--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -51,20 +51,21 @@ get_age_group <- function(data, col_age, max_val, min_val = 0, step) {
   checkmate::assert_number(step, lower = 1, upper = max_val)
 
   # get breaks
-  n_steps <- as.integer((max_val - min_val) / step) + 1
-  limits_low <- seq.int(
-    min_val, max_val,
-    length.out = n_steps
-  )
-  limits_high <- limits_low + step
+  limits_low <- seq.int(min_val, max_val, by = step)
+  limits_high <- limits_low + step - 1
 
   # prepare labels
   lim_labels <- paste(limits_low, limits_high, sep = "-")
   lim_labels[length(lim_labels)] <- paste0(
-    ">",
-    limits_low[length(limits_low)]
+    ">", limits_low[length(limits_low)]
   )
-  lim_breaks <- c(-Inf, limits_low[seq(2, length(limits_low))] - 1, Inf)
+  if (min_val == 0) {
+    lim_breaks <- c(limits_low[seq(1, length(limits_low))] - 1, Inf)
+  }  else {
+    lim_labels <- c(paste0("<", min_val - 1), lim_labels)
+    lim_breaks <- c(-Inf, limits_low[seq(1, length(limits_low))] - 1, Inf)
+
+  }
 
   # cut the age data and apply labels
   age_group <- cut(data[[col_age]],

--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -47,9 +47,9 @@ get_age_group <- function(data, col_age, max_val, min_val = 0, step) {
     names(data),
     must.include = col_age
   )
-  checkmate::assert_integerish(min_val, lower = 0, upper = max_val)
-  checkmate::assert_integerish(max_val, lower = min_val)
-  checkmate::assert_integerish(step, lower = 1, upper = max_val)
+  checkmate::assert_int(min_val, lower = 0)
+  checkmate::assert_int(max_val, lower = min_val)
+  checkmate::assert_int(step, lower = 1, upper = max_val)
 
   # get breaks
   limits_low <- seq.int(min_val, max_val, by = step)

--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -47,9 +47,9 @@ get_age_group <- function(data, col_age, max_val, min_val = 0, step) {
     names(data),
     must.include = col_age
   )
-  checkmate::assert_number(min_val, lower = 0)
-  checkmate::assert_number(max_val, lower = min_val)
-  checkmate::assert_number(step, lower = 1, upper = max_val)
+  checkmate::assert_integerish(min_val, lower = 0)
+  checkmate::assert_integerish(max_val, lower = min_val)
+  checkmate::assert_integerish(step, lower = 1, upper = max_val)
 
   # get breaks
   limits_low <- seq.int(min_val, max_val, by = step)

--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -47,7 +47,7 @@ get_age_group <- function(data, col_age, max_val, min_val = 0, step) {
     names(data),
     must.include = col_age
   )
-  checkmate::assert_integerish(min_val, lower = 0)
+  checkmate::assert_integerish(min_val, lower = 0, upper = max_val)
   checkmate::assert_integerish(max_val, lower = min_val)
   checkmate::assert_integerish(step, lower = 1, upper = max_val)
 

--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -1,15 +1,15 @@
 #' @title Construct age-group variable from age column
 #'
 #' @description This method splits an age interval from `min_val` to `max_val`
-#' into intervals of size `step``.ç
+#' into intervals of size `step`.
 #' If the method finds ages greater or equal than `max_val`
 #' it assigns the string `">max_val"`.
 #' By default `min_val` is set to 0, however it can be assigned by
 #' convenience. If the method finds ages lower or equal
 #' than `min_val` it assigns the string `"<min_val-1"`.
-#' The function warns when (max_val - min_val) %% step != 0. In that case
-#' the last interval is truncated to the closest upper value to max_val that
-#' satisfies (closest_upper - min_val) %% step == 0.
+#' The function warns when (max_val - min_val) is not an integer multiple of
+#' step. In that case the last interval is truncated to the upper value
+#' closest to max_val for which (closest_upper - min_val) is multiple of step.
 #'
 #' @param data dataset with at least a column containing the age
 #' information

--- a/R/all_data_prep.R
+++ b/R/all_data_prep.R
@@ -1,14 +1,15 @@
 #' @title Construct age-group variable from age column
 #'
 #' @description This method splits an age interval from `min_val` to `max_val`
-#' into `(max_val - min_val) / step` intervals.
-#' By default `min_val` is set to 0, however it can be assigned by
-#' convenience.
+#' into intervals of size `step``.ç
 #' If the method finds ages greater or equal than `max_val`
 #' it assigns the string `">max_val"`.
-#' To avoid errors it is necessary to set `step < max_val`.
-#' It is also suggested to choose the step such
-#' that `max_val %% (step + 1) == 0`.
+#' By default `min_val` is set to 0, however it can be assigned by
+#' convenience. If the method finds ages lower or equal
+#' than `min_val` it assigns the string `"<min_val-1"`.
+#' The function warns when (max_val - min_val) %% step != 0. In that case
+#' the last interval is truncated to the closest upper value to max_val that
+#' satisfies (closest_upper - min_val) %% step == 0.
 #'
 #' @param data dataset with at least a column containing the age
 #' information
@@ -64,7 +65,14 @@ get_age_group <- function(data, col_age, max_val, min_val = 0, step) {
   }  else {
     lim_labels <- c(paste0("<", min_val - 1), lim_labels)
     lim_breaks <- c(-Inf, limits_low[seq(1, length(limits_low))] - 1, Inf)
+  }
 
+  #Warning of module condition not satisfied
+  if ((max_val - min_val) %% step != 0) {
+    war_msg <- "The values provided do not satisfy (max_val-min_val)%%step = 0.
+    The last interval will be truncated to "
+    war_msg <- paste0(war_msg, lim_labels[length(lim_labels)])
+    warning(war_msg)
   }
 
   # cut the age data and apply labels

--- a/man/get_age_group.Rd
+++ b/man/get_age_group.Rd
@@ -26,14 +26,10 @@ Ages above \code{max_val} are represented as \verb{>max_val}.
 }
 \description{
 This method splits an age interval from \code{min_val} to \code{max_val}
-into \code{(max_val - min_val) / step} intervals.
-By default \code{min_val} is set to 0, however it can be assigned by
-convenience.
-If the method finds ages greater or equal than \code{max_val}
-it assigns the string \code{">max_val"}.
-To avoid errors it is necessary to set \code{step < max_val}.
-It is also suggested to choose the step such
-that \code{max_val \%\% (step + 1) == 0}.
+into intervals of size \verb{step``.ç If the method finds ages greater or equal than }max_val\verb{it assigns the string}">max_val"\verb{. By default }min_val\verb{is set to 0, however it can be assigned by convenience. If the method finds ages lower or equal than}min_val\verb{it assigns the string}"<min_val-1"`.
+The function warns when (max_val - min_val) \%\% step != 0. In that case
+the last interval is truncated to the closest upper value to max_val that
+satisfies (closest_upper - min_val) \%\% step == 0.
 }
 \examples{
 # load data provided with the package

--- a/man/get_age_group.Rd
+++ b/man/get_age_group.Rd
@@ -45,7 +45,7 @@ cohortdata$age_group <- get_age_group(
   data = cohortdata,
   col_age = "age",
   max_val = 80,
-  step = 9
+  step = 10
 )
 
 # view the data frame with new column

--- a/man/get_age_group.Rd
+++ b/man/get_age_group.Rd
@@ -26,10 +26,15 @@ Ages above \code{max_val} are represented as \verb{>max_val}.
 }
 \description{
 This method splits an age interval from \code{min_val} to \code{max_val}
-into intervals of size \verb{step``.ç If the method finds ages greater or equal than }max_val\verb{it assigns the string}">max_val"\verb{. By default }min_val\verb{is set to 0, however it can be assigned by convenience. If the method finds ages lower or equal than}min_val\verb{it assigns the string}"<min_val-1"`.
-The function warns when (max_val - min_val) \%\% step != 0. In that case
-the last interval is truncated to the closest upper value to max_val that
-satisfies (closest_upper - min_val) \%\% step == 0.
+into intervals of size \code{step}.
+If the method finds ages greater or equal than \code{max_val}
+it assigns the string \code{">max_val"}.
+By default \code{min_val} is set to 0, however it can be assigned by
+convenience. If the method finds ages lower or equal
+than \code{min_val} it assigns the string \code{"<min_val-1"}.
+The function warns when (max_val - min_val) is not an integer multiple of
+step. In that case the last interval is truncated to the upper value
+closest to max_val for which (closest_upper - min_val) is multiple of step.
 }
 \examples{
 # load data provided with the package

--- a/man/vaccineff-package.Rd
+++ b/man/vaccineff-package.Rd
@@ -22,7 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
-  \item David Santiago Quevedo \email{ex-dsquevedo@javeriana.edu.co} (\href{https://orcid.org/0000-0003-1583-4262)}{ORCID})
+  \item David Santiago Quevedo \email{ex-dsquevedo@javeriana.edu.co} (\href{https://orcid.org/0000-0003-1583-4262}{ORCID})
   \item Santiago Loaiza \email{santiago.loaiza@javeriana.edu.co} (\href{https://orcid.org/0000-0002-2092-3262}{ORCID})
 }
 

--- a/tests/testthat/test-cohort_effectiveness.R
+++ b/tests/testthat/test-cohort_effectiveness.R
@@ -103,7 +103,7 @@ test_that("`coh_test_noconf`: accept PH", {
     data = cohortdata,
     col_age = "age",
     max_val = 80,
-    step = 9
+    step = 10
   )
   cohortdata_3039 <- cohortdata[cohortdata$age_group == "30-39", ]
 

--- a/tests/testthat/test-get_age_group.R
+++ b/tests/testthat/test-get_age_group.R
@@ -24,23 +24,16 @@ test_that("`get_age_groups`: basic expectations", {
   expect_length(
     unique(age_groups),
     # manual cutting of age groups - ROUGHLY CORRECT
-    length(
-      levels(
-        cut(
-          cohortdata$age,
-          breaks = c(
-            -Inf,
-            seq(step_size, max_val, step_size),
-            Inf
-          )
+    nlevels(
+      cut(
+        cohortdata$age,
+        breaks = c(
+          -Inf,
+          seq(step_size, max_val, step_size),
+          Inf
         )
       )
     )
-  )
-  # check that last value is the same as max_val
-  expect_identical(
-    tail(levels(age_groups), 1),
-    sprintf(">%i", max_val) # hacky test to avoid regex extraction
   )
 
   # check that breaks are correct
@@ -54,7 +47,7 @@ test_that("`get_age_groups`: basic expectations", {
         step = 50
       )
     ),
-    c("0-50", ">80")
+    c("0-49", ">50")
   )
 })
 
@@ -136,5 +129,25 @@ test_that("`get_age_groups`: Input checking", {
       "Assertion on 'step' failed: Element 1 is not <= %i",
       max_age
     )
+  )
+})
+
+# tests to check for min_val != 0
+test_that("`get_age_groups`: non-zero min_val", {
+  min_val <- 10
+  cohortdata$age_group <- get_age_group(
+    data = cohortdata,
+    col_age = "age",
+    max_val = 80,
+    min_val = min_val,
+    step = 9
+  )
+
+  #expect none NA values are expected
+  expect_length(cohortdata[is.na(cohortdata$age_group), ]$age_group, 0)
+
+  #Check for registers < min_val
+  expect_true(
+    all(cohortdata[cohortdata$age < min_val, ]$age_group == "<9")
   )
 })

--- a/tests/testthat/test-get_age_group.R
+++ b/tests/testthat/test-get_age_group.R
@@ -110,6 +110,17 @@ test_that("`get_age_groups`: Input checking", {
     regexp = "Assertion on 'min_val' failed: May not be NA"
   )
 
+  # non-integer values passed
+  expect_error(
+    get_age_group(
+      data = cohortdata,
+      col_age = "age",
+      min_val = 0.7,
+      max_val = 1,
+      step = 1
+    )
+  )
+
   # step size is larger than difference in age limits
   # maximum age is less than the minimum age
   max_age <- 80

--- a/tests/testthat/test-get_age_group.R
+++ b/tests/testthat/test-get_age_group.R
@@ -7,13 +7,13 @@ data("cohortdata")
 test_that("`get_age_groups`: basic expectations", {
   # prepare a vector of binned ages
   max_val <- 80
-  step_size <- 7
+  step_size <- 10
 
   age_groups <- get_age_group(
     data = cohortdata,
     col_age = "age",
-    max_val = 80,
-    step = 7
+    max_val = max_val,
+    step = step_size
   )
 
   # basic checks for return type
@@ -38,16 +38,13 @@ test_that("`get_age_groups`: basic expectations", {
 
   # check that breaks are correct
   # expect 0-50 and >80
-  expect_identical(
-    levels(
-      get_age_group(
-        data = cohortdata,
-        col_age = "age",
-        max_val = 80,
-        step = 50
-      )
-    ),
-    c("0-49", ">50")
+  expect_warning(
+    get_age_group(
+      data = cohortdata,
+      col_age = "age",
+      max_val = 80,
+      step = 50
+    )
   )
 })
 
@@ -140,7 +137,7 @@ test_that("`get_age_groups`: non-zero min_val", {
     col_age = "age",
     max_val = 80,
     min_val = min_val,
-    step = 9
+    step = 10
   )
 
   #expect none NA values are expected


### PR DESCRIPTION
Fixed `get_age_group()` responding to issue https://github.com/epiverse-trace/vaccineff/issues/38. Main changes:
* Age intervals are defined directly by `step` from `min_val`  to `max_val`.
* When `(max_val- min_val)%%setp != 0`, a warning is returned and the function uses the closest lower value to [ 
`max_val` that satisfies the condition.
* When `min_val !=0`  the ages lower than `min_val` are grouped  in the interval `<min_val`
* Refactorization of tests for `get_age_group()` responding to its new characteristics
* Updated documentation of the function
* Refactorization of the last test for `coh_test_noconf` 
