### PR TITLE
Use assert_names() instead of expect_names()

### DIFF
--- a/R/coh_matching.R
+++ b/R/coh_matching.R
@@ -179,11 +179,9 @@ get_censoring_date_match <- function(data,
     must.include = c(outcome_date_col, censoring_date_col)
   )
   # check for subclass
-  checkmate::expect_names(
+  checkmate::assert_names(
     colnames(data),
-    must.include = "subclass",
-    info = "'subclass' column from match must be included in 'data' to \
-      identify matched couples."
+    must.include = "subclass"
   )
 
   # check for date type

--- a/R/coh_matching.R
+++ b/R/coh_matching.R
@@ -173,6 +173,11 @@ get_censoring_date_match <- function(data,
     data,
     min.rows = 1L
   )
+
+  # check for string type
+  checkmate::assert_string(outcome_date_col)
+  checkmate::assert_string(censoring_date_col)
+
   # check for names in data
   checkmate::assert_names(
     colnames(data),
@@ -182,10 +187,6 @@ get_censoring_date_match <- function(data,
   # check for date type
   checkmate::assert_date(data[[outcome_date_col]])
   checkmate::assert_date(data[[censoring_date_col]])
-
-  # check for string type
-  checkmate::assert_string(outcome_date_col)
-  checkmate::assert_string(censoring_date_col)
 
   # create censoring date for every couple indexed by subclass
   censoring_date <- unlist(

--- a/R/coh_matching.R
+++ b/R/coh_matching.R
@@ -176,12 +176,7 @@ get_censoring_date_match <- function(data,
   # check for names in data
   checkmate::assert_names(
     colnames(data),
-    must.include = c(outcome_date_col, censoring_date_col)
-  )
-  # check for subclass
-  checkmate::assert_names(
-    colnames(data),
-    must.include = "subclass"
+    must.include = c(outcome_date_col, censoring_date_col, "subclass")
   )
 
   # check for date type


### PR DESCRIPTION
Since expect_names() is intended to be used in tests only and will trigger loading of testthat (fix #46).

The only potential downside is that the extra context provided in `info` is no longer available. If you believe this is important, we will have to test this "manually" with `stopifnot()` rather than relying on checkmate.
