### PR TITLE
Add CITATION.cff & related GHA workflow

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^scratch\.R$
+^CITATION\.cff$

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -1,0 +1,59 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# The action runs when:
+# - The DESCRIPTION or inst/CITATION are modified
+# - Can be run manually
+# For customizing the triggers, visit https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - DESCRIPTION
+      - inst/CITATION
+      - .github/workflows/update-citation-cff.yaml
+  workflow_dispatch:
+
+name: Update CITATION.cff
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-citation-cff:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::cffr
+            any::V8
+
+      - name: Update CITATION.cff
+        run: |
+
+          library(cffr)
+
+          # Customize with your own code
+          # See https://docs.ropensci.org/cffr/articles/cffr.html
+
+          # Write your own keys
+          mykeys <- list()
+
+          # Create your CITATION.cff file
+          cff_write(keys = mykeys)
+
+        shell: Rscript {0}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Update `CITATION.cff`
+          title: Update `CITATION.cff`
+          body: |
+            This pull request updates the citation file, ensuring all authors are credited and there are no discrepancies.
+
+            Please verify the changes before merging. 
+          branch: update-citation-cff

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,272 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "vaccineff" in publications use:'
+type: software
+license: MIT
+title: 'vaccineff: Estimate Vaccine Effectiveness Based on Different Study Designs'
+version: 0.0.1
+abstract: R package with tools for estimating vaccine effectiveness and vaccine related
+  metrics.
+authors:
+- family-names: Quevedo
+  given-names: David Santiago
+  email: ex-dsquevedo@javeriana.edu.co
+  orcid: https://orcid.org/0000-0003-1583-4262
+- family-names: Cucunubá
+  given-names: Zulma M.
+  email: zulma.cucunuba@javeriana.edu.co
+  orcid: https://orcid.org/0000-0002-8165-3198
+repository-code: https://github.com/epiverse-trace/vaccineff
+url: https://epiverse-trace.github.io/vaccineff/
+contact:
+- family-names: Cucunubá
+  given-names: Zulma M.
+  email: zulma.cucunuba@javeriana.edu.co
+  orcid: https://orcid.org/0000-0002-8165-3198
+keywords:
+- epidemiology
+- epiverse
+- r
+- r-package
+- vaccine-effectiveness
+references:
+- type: software
+  title: 'R: A Language and Environment for Statistical Computing'
+  notes: Depends
+  url: https://www.R-project.org/
+  authors:
+  - name: R Core Team
+  institution:
+    name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2024'
+  version: '>= 3.5.0'
+- type: software
+  title: survival
+  abstract: 'survival: Survival Analysis'
+  notes: Imports
+  url: https://github.com/therneau/survival
+  repository: https://CRAN.R-project.org/package=survival
+  authors:
+  - family-names: Therneau
+    given-names: Terry M
+    email: therneau.terry@mayo.edu
+  year: '2024'
+  doi: 10.32614/CRAN.package.survival
+- type: software
+  title: stats
+  abstract: 'R: A Language and Environment for Statistical Computing'
+  notes: Imports
+  authors:
+  - name: R Core Team
+  institution:
+    name: R Foundation for Statistical Computing
+    address: Vienna, Austria
+  year: '2024'
+  doi: 10.32614/CRAN.package.stats
+- type: software
+  title: checkmate
+  abstract: 'checkmate: Fast and Versatile Argument Checks'
+  notes: Imports
+  url: https://mllg.github.io/checkmate/
+  repository: https://CRAN.R-project.org/package=checkmate
+  authors:
+  - family-names: Lang
+    given-names: Michel
+    email: michellang@gmail.com
+    orcid: https://orcid.org/0000-0001-9754-0393
+  year: '2024'
+  doi: 10.32614/CRAN.package.checkmate
+- type: software
+  title: ggplot2
+  abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
+  notes: Imports
+  url: https://ggplot2.tidyverse.org
+  repository: https://CRAN.R-project.org/package=ggplot2
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+    orcid: https://orcid.org/0000-0003-4757-117X
+  - family-names: Chang
+    given-names: Winston
+    orcid: https://orcid.org/0000-0002-1576-2126
+  - family-names: Henry
+    given-names: Lionel
+  - family-names: Pedersen
+    given-names: Thomas Lin
+    email: thomas.pedersen@posit.co
+    orcid: https://orcid.org/0000-0002-5147-4711
+  - family-names: Takahashi
+    given-names: Kohske
+  - family-names: Wilke
+    given-names: Claus
+    orcid: https://orcid.org/0000-0002-7470-9261
+  - family-names: Woo
+    given-names: Kara
+    orcid: https://orcid.org/0000-0002-5125-4188
+  - family-names: Yutani
+    given-names: Hiroaki
+    orcid: https://orcid.org/0000-0002-3385-7233
+  - family-names: Dunnington
+    given-names: Dewey
+    orcid: https://orcid.org/0000-0002-9415-4582
+  - family-names: Brand
+    given-names: Teun
+    name-particle: van den
+    orcid: https://orcid.org/0000-0002-9335-7468
+  year: '2024'
+  doi: 10.32614/CRAN.package.ggplot2
+- type: software
+  title: scales
+  abstract: 'scales: Scale Functions for Visualization'
+  notes: Imports
+  url: https://scales.r-lib.org
+  repository: https://CRAN.R-project.org/package=scales
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Pedersen
+    given-names: Thomas Lin
+    email: thomas.pedersen@posit.co
+    orcid: https://orcid.org/0000-0002-5147-4711
+  - family-names: Seidel
+    given-names: Dana
+  year: '2024'
+  doi: 10.32614/CRAN.package.scales
+- type: software
+  title: rlang
+  abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
+  notes: Imports
+  url: https://rlang.r-lib.org
+  repository: https://CRAN.R-project.org/package=rlang
+  authors:
+  - family-names: Henry
+    given-names: Lionel
+    email: lionel@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2024'
+  doi: 10.32614/CRAN.package.rlang
+- type: software
+  title: MatchIt
+  abstract: 'MatchIt: Nonparametric Preprocessing for Parametric Causal Inference'
+  notes: Imports
+  url: https://kosukeimai.github.io/MatchIt/
+  repository: https://CRAN.R-project.org/package=MatchIt
+  authors:
+  - family-names: Ho
+    given-names: Daniel
+    email: daniel.e.ho@gmail.com
+    orcid: https://orcid.org/0000-0002-2195-5469
+  - family-names: Imai
+    given-names: Kosuke
+    email: imai@harvard.edu
+    orcid: https://orcid.org/0000-0002-2748-1022
+  - family-names: King
+    given-names: Gary
+    email: king@harvard.edu
+    orcid: https://orcid.org/0000-0002-5327-7631
+  - family-names: Stuart
+    given-names: Elizabeth
+    email: estuart@jhu.edu
+    orcid: https://orcid.org/0000-0002-9042-8611
+  - family-names: Greifer
+    given-names: Noah
+    email: noah.greifer@gmail.com
+    orcid: https://orcid.org/0000-0003-3067-7154
+  year: '2024'
+  doi: 10.32614/CRAN.package.MatchIt
+- type: software
+  title: knitr
+  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
+  notes: Suggests
+  url: https://yihui.org/knitr/
+  repository: https://CRAN.R-project.org/package=knitr
+  authors:
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  year: '2024'
+  doi: 10.32614/CRAN.package.knitr
+- type: software
+  title: rmarkdown
+  abstract: 'rmarkdown: Dynamic Documents for R'
+  notes: Suggests
+  url: https://pkgs.rstudio.com/rmarkdown/
+  repository: https://CRAN.R-project.org/package=rmarkdown
+  authors:
+  - family-names: Allaire
+    given-names: JJ
+    email: jj@posit.co
+  - family-names: Xie
+    given-names: Yihui
+    email: xie@yihui.name
+    orcid: https://orcid.org/0000-0003-0645-5666
+  - family-names: Dervieux
+    given-names: Christophe
+    email: cderv@posit.co
+    orcid: https://orcid.org/0000-0003-4474-2498
+  - family-names: McPherson
+    given-names: Jonathan
+    email: jonathan@posit.co
+  - family-names: Luraschi
+    given-names: Javier
+  - family-names: Ushey
+    given-names: Kevin
+    email: kevin@posit.co
+  - family-names: Atkins
+    given-names: Aron
+    email: aron@posit.co
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  - family-names: Cheng
+    given-names: Joe
+    email: joe@posit.co
+  - family-names: Chang
+    given-names: Winston
+    email: winston@posit.co
+  - family-names: Iannone
+    given-names: Richard
+    email: rich@posit.co
+    orcid: https://orcid.org/0000-0003-3925-190X
+  year: '2024'
+  doi: 10.32614/CRAN.package.rmarkdown
+- type: software
+  title: spelling
+  abstract: 'spelling: Tools for Spell Checking in R'
+  notes: Suggests
+  url: https://ropensci.r-universe.dev/spelling
+  repository: https://CRAN.R-project.org/package=spelling
+  authors:
+  - family-names: Ooms
+    given-names: Jeroen
+    email: jeroen@berkeley.edu
+    orcid: https://orcid.org/0000-0002-4035-0289
+  - family-names: Hester
+    given-names: Jim
+    email: james.hester@rstudio.com
+  year: '2024'
+  doi: 10.32614/CRAN.package.spelling
+- type: software
+  title: testthat
+  abstract: 'testthat: Unit Testing for R'
+  notes: Suggests
+  url: https://testthat.r-lib.org
+  repository: https://CRAN.R-project.org/package=testthat
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2024'
+  doi: 10.32614/CRAN.package.testthat
+  version: '>= 3.0.0'
+


### PR DESCRIPTION
CFF files are a standard format for storing bibliographic information, used across many different languages (as opposed to the `inst/CITATION` file which is specific to R packages). It allows citation in a streamlined way from GitHub web interface, and automatically curates metadata on Zenodo.
