### PR TITLE
Compatibility with ggplot2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Depends:
     R (>= 4.2.0)
 Imports:
     checkmate,
-    ggplot2,
+    ggplot2 (>= 3.5.2),
     linelist,
     MatchIt,
     rlang,

--- a/tests/testthat/test-utils_coverage.R
+++ b/tests/testthat/test-utils_coverage.R
@@ -35,7 +35,12 @@ test_that("`plot_coverage`: default plot", {
     cumulative = FALSE
   )
 
-  expect_identical(plt$labels$y, "coverage * max(dose_plot)")
+  labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    expect_identical(ggplot2::get_labs(plt)$y, "Doses per day")
+  } else {
+    expect_identical(plt$labels$y, "coverage * max(dose_plot)")
+  }
+
   expect_identical(plt$data$doses, plt$data$dose_plot)
 })
 
@@ -47,6 +52,11 @@ test_that("`plot_coverage`: cumulative plot", {
     cumulative = TRUE
   )
 
-  expect_identical(plt$labels$y, "coverage * max(dose_plot)")
+  labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    expect_identical(ggplot2::get_labs(plt)$y, "Doses per day")
+  } else {
+    expect_identical(plt$labels$y, "coverage * max(dose_plot)")
+  }
+
   expect_identical(plt$data$cum_doses, plt$data$dose_plot)
 })

--- a/tests/testthat/test-utils_coverage.R
+++ b/tests/testthat/test-utils_coverage.R
@@ -35,11 +35,7 @@ test_that("`plot_coverage`: default plot", {
     cumulative = FALSE
   )
 
-  labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
-    expect_identical(ggplot2::get_labs(plt)$y, "Doses per day")
-  } else {
-    expect_identical(plt$labels$y, "coverage * max(dose_plot)")
-  }
+  expect_identical(ggplot2::get_labs(plt)$y, "Doses per day")
 
   expect_identical(plt$data$doses, plt$data$dose_plot)
 })
@@ -52,11 +48,7 @@ test_that("`plot_coverage`: cumulative plot", {
     cumulative = TRUE
   )
 
-  labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
-    expect_identical(ggplot2::get_labs(plt)$y, "Doses per day")
-  } else {
-    expect_identical(plt$labels$y, "coverage * max(dose_plot)")
-  }
+  expect_identical(ggplot2::get_labs(plt)$y, "Doses per day")
 
   expect_identical(plt$data$cum_doses, plt$data$dose_plot)
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first and ignoring the PR template.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the vaccineff package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun