### PR TITLE
fix(tests): update snapshot cohort matching

### DIFF
--- a/tests/testthat/_snaps/coh_match_utils.md
+++ b/tests/testthat/_snaps/coh_match_utils.md
@@ -5,6 +5,6 @@
     Output
                   u   v
       All       364 636
-      Matched   359 359
-      Unmatched   5 277
+      Matched   358 358
+      Unmatched   6 278
 


### PR DESCRIPTION
In response to the deadline for vaccineff's archival, this is updating the snapshot such that it will not be archived. PR for testing/verification purposes.
